### PR TITLE
Feature/add option to confine to projects

### DIFF
--- a/Instance_tagger.php
+++ b/Instance_tagger.php
@@ -205,6 +205,9 @@ class Instance_tagger extends \ExternalModules\AbstractExternalModule
      */
     public function redcap_every_page_top($project_id)
     {
+        if ($this->getSystemSetting('display_on_projects_only') && !isset($project_id)) {
+            return;
+        }
         $this->init_tagger();
         if ($this->selected === 1) {
             echo $this->js;

--- a/config.json
+++ b/config.json
@@ -15,6 +15,12 @@
   "enable-every-page-hooks-on-system-pages": true,
   "system-settings": [
     {
+      "key": "display_on_projects_only",
+      "name": "Display only in projects? (Default is system wide)",
+      "required": false,
+      "type": "checkbox"
+    },
+    {
       "key": "localhost_url",
       "name": "Localhost URL",
       "required": false,

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
   "system-settings": [
     {
       "key": "display_on_projects_only",
-      "name": "Display only in projects? (Default is system wide)",
+      "name": "Display only in projects? (Default is system wide and on enabled projects)",
       "required": false,
       "type": "checkbox"
     },


### PR DESCRIPTION
Hi @biggeeves,

This may be out of the scope of your module, but we are considering using your module for a different purpose, adding a banner on (specific) project pages, necessitating that the banner not be displayed outside of projects for which it is not enabled.

This PR allows that much and may be useful to you.