### PR TITLE
Compatibility fix for PHP 8

### DIFF
--- a/Instance_tagger.php
+++ b/Instance_tagger.php
@@ -75,7 +75,7 @@ class Instance_tagger extends \ExternalModules\AbstractExternalModule
         $this->instance_url['staging'] = AbstractExternalModule::getSystemSetting('staging_url');
         $this->instance_url['other'] = AbstractExternalModule::getSystemSetting('other_url');
         $this->other_text = AbstractExternalModule::getSystemSetting('other_text');
-        $this->other_text = htmlspecialchars(strip_tags($this->other_text));
+        $this->other_text = (!is_null($this->other_text) ? htmlspecialchars(strip_tags($this->other_text)) : '');
         $this->offset_top = AbstractExternalModule::getSystemSetting('offset_top');
         $this->offset_right = AbstractExternalModule::getSystemSetting('offset_right');
         $this->offset_bottom = AbstractExternalModule::getSystemSetting('offset_bottom');
@@ -184,7 +184,7 @@ class Instance_tagger extends \ExternalModules\AbstractExternalModule
     {
         $this->selected = 0;
         foreach ($this->instance_url as $key => $value) {
-            if (strpos(APP_PATH_WEBROOT_FULL, $value) !== false) {
+            if (!is_null($value) && strpos(APP_PATH_WEBROOT_FULL, $value) !== false) {
 
                 $this->instance = $key;
                 $this->display_text = ucfirst($key);


### PR DESCRIPTION
Fixes the following two PHP 8 errors causing module to shut down or label to default to 'Localhost':
1. Deprecated - strpos(): Passing null to parameter # 2 ($needle) of type string is deprecated. Line: 187
2. Undefined constant "DCC\Instance_tagger\other_text" in Instance_tagger.php:78